### PR TITLE
fix(backend): fix next token in ListApplications API

### DIFF
--- a/aws-serverless-app-repo-reference-backend/src/main/java/com/amazonaws/serverless/apprepo/api/impl/ApplicationsService.java
+++ b/aws-serverless-app-repo-reference-backend/src/main/java/com/amazonaws/serverless/apprepo/api/impl/ApplicationsService.java
@@ -180,9 +180,9 @@ public class ApplicationsService implements ApplicationsApi {
 
     ApplicationList result = new ApplicationList()
           .applications(applicationSummaries);
-    if (queryResponse.lastEvaluatedKey() != null) {
-      result.nextToken(paginationTokenSerializer
-            .serialize(queryResponse.lastEvaluatedKey()));
+    Map<String, AttributeValue> lastEvaluatedKey = queryResponse.lastEvaluatedKey();
+    if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+      result.nextToken(paginationTokenSerializer.serialize(lastEvaluatedKey));
     }
     return result;
   }

--- a/aws-serverless-app-repo-reference-backend/src/test/java/com/amazonaws/serverless/apprepo/api/impl/ApplicationsServiceTest.java
+++ b/aws-serverless-app-repo-reference-backend/src/test/java/com/amazonaws/serverless/apprepo/api/impl/ApplicationsServiceTest.java
@@ -242,24 +242,7 @@ public class ApplicationsServiceTest {
   @Test
   public void listApplications_nextToken_exception() throws Exception {
     String userId = UUID.randomUUID().toString();
-    String applicationId = UUID.randomUUID().toString();
     String nextToken = UUID.randomUUID().toString();
-
-    Map<String, AttributeValue> recordMap = keyMap(userId, applicationId);
-
-    Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
-    expressionAttributeValues.put(":u", AttributeValue.builder()
-          .s(userId)
-          .build());
-    QueryRequest expectedQueryRequest = QueryRequest.builder()
-          .consistentRead(true)
-          .tableName(TABLE_NAME)
-          .keyConditionExpression(String.format("%s = :u",
-                ApplicationRecord.USER_ID_ATTRIBUTE_NAME))
-          .expressionAttributeValues(expressionAttributeValues)
-          .limit(ApplicationsService.DEFAULT_LIST_APPLICATIONS_LIMIT)
-          .exclusiveStartKey(recordMap)
-          .build();
 
     when(principal.getName()).thenReturn(userId);
     Mockito.doThrow(InvalidTokenException.class).when(tokenSerializer).deserialize(nextToken);

--- a/aws-serverless-app-repo-reference-backend/src/test/java/com/amazonaws/serverless/apprepo/cucumber/steps/ListApplicationsSteps.java
+++ b/aws-serverless-app-repo-reference-backend/src/test/java/com/amazonaws/serverless/apprepo/cucumber/steps/ListApplicationsSteps.java
@@ -83,7 +83,8 @@ public class ListApplicationsSteps {
                 .creationTime(app.getCreationTime()))
           .collect(Collectors.toList());
 
-    Assertions.assertThat(TestEnv.getApplicationList().getApplications()).containsAll(expectedApplicationSummaries);
+    assertThat(TestEnv.getApplicationList().getApplications()).containsAll(expectedApplicationSummaries);
+    assertThat(TestEnv.getApplicationList().getNextToken()).isNull();
   }
 
   @Then("([1-9][0-9]*)? applications should be listed")
@@ -122,7 +123,7 @@ public class ListApplicationsSteps {
   @And("the listed applications should be in alphabetical order")
   public void the_listed_applications_should_be_in_alphabetical_order() {
     Preconditions.checkState(TestEnv.getApplicationList() != null, "Step assumes listApplications has been called");
-    Assertions.assertThat(TestEnv.getApplicationList().getApplications())
+    assertThat(TestEnv.getApplicationList().getApplications())
           .isSortedAccordingTo(Comparator.comparing(ApplicationSummary::getApplicationId));
   }
 }


### PR DESCRIPTION
*Description of changes:*
In AWS SDK v2, it creates an empty Map for LastEvaluatedKey even when DynamoDB query does not have next page.

Change the code to handle LastEvaluatedKey map empty case

*Tests*
Added integ tests to verify next token is null when there is no more applications in ListApplications API


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
