### PR TITLE
feat: add GitHubOwner as a parameter of the CICD templates

### DIFF
--- a/analytics/sam/cicd/template.yaml
+++ b/analytics/sam/cicd/template.yaml
@@ -8,6 +8,10 @@ Parameters:
     Type: String
     Description: The AWS Secrets Manager Secret Id that stores Github OAuth token.
     Default: 'GitHubOAuthToken'
+  GitHubOwner:
+    Type: String
+    Description: The GitHub owner of the repository.
+    Default: 'awslabs'
   ApplicationStackName:
     Type: String
     Description: The stack name the CICD will deploy the application to.
@@ -25,7 +29,7 @@ Resources:
         SemanticVersion: 0.1.3
       Parameters:
         GitHubOAuthToken: !Sub '{{resolve:secretsmanager:${GitHubOAuthTokenSecretId}}}'
-        GitHubOwner: awslabs
+        GitHubOwner: !Ref GitHubOwner
         GitHubRepo: realworld-serverless-application
         DeployStackName: !Ref ApplicationStackName
         DeployRoleName: !Ref DeployRole

--- a/backend/sam/cicd/template.yaml
+++ b/backend/sam/cicd/template.yaml
@@ -8,6 +8,10 @@ Parameters:
     Type: String
     Description: The AWS Secrets Manager Secret Id that stores Github OAuth token.
     Default: 'GitHubOAuthToken'
+  GitHubOwner:
+    Type: String
+    Description: The GitHub owner of the repository.
+    Default: 'awslabs'
   ApplicationStackName:
     Type: String
     Description: The stack name the CD pipeline will use to deploy the application.
@@ -25,7 +29,7 @@ Resources:
         SemanticVersion: 0.1.3
       Parameters:
         GitHubOAuthToken: !Sub '{{resolve:secretsmanager:${GitHubOAuthTokenSecretId}}}'
-        GitHubOwner: awslabs
+        GitHubOwner: !Ref GitHubOwner
         GitHubRepo: realworld-serverless-application
         DeployStackName: !Ref ApplicationStackName
         DeployRoleName: !Ref DeployRole

--- a/ops/sam/cicd/template.yaml
+++ b/ops/sam/cicd/template.yaml
@@ -8,6 +8,10 @@ Parameters:
     Type: String
     Description: The AWS Secrets Manager Secret Id that stores Github OAuth token.
     Default: 'GitHubOAuthToken'
+  GitHubOwner:
+    Type: String
+    Description: The GitHub owner of the repository.
+    Default: 'awslabs'
   ApplicationStackName:
     Type: String
     Description: The stack name the CICD will deploy the application to.
@@ -25,7 +29,7 @@ Resources:
         SemanticVersion: 0.1.3
       Parameters:
         GitHubOAuthToken: !Sub '{{resolve:secretsmanager:${GitHubOAuthTokenSecretId}}}'
-        GitHubOwner: awslabs
+        GitHubOwner: !Ref GitHubOwner
         GitHubRepo: realworld-serverless-application
         DeployStackName: !Ref ApplicationStackName
         DeployRoleName: !Ref DeployRole

--- a/static-website/sam/cicd/template.yaml
+++ b/static-website/sam/cicd/template.yaml
@@ -8,6 +8,10 @@ Parameters:
     Type: String
     Description: The AWS Secrets Manager Secret Id that stores Github OAuth token.
     Default: 'GitHubOAuthToken'
+  GitHubOwner:
+    Type: String
+    Description: The GitHub owner of the repository.
+    Default: 'awslabs'
   ApplicationStackName:
     Type: String
     Description: The stack name the CD pipeline will use to deploy the application.
@@ -25,7 +29,7 @@ Resources:
         SemanticVersion: 0.1.3
       Parameters:
         GitHubOAuthToken: !Sub '{{resolve:secretsmanager:${GitHubOAuthTokenSecretId}}}'
-        GitHubOwner: awslabs
+        GitHubOwner: !Ref GitHubOwner
         GitHubRepo: realworld-serverless-application
         DeployStackName: !Ref ApplicationStackName
         DeployRoleName: !Ref DeployRole


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add GitHubOwner as a parameter of the CICD templates so that customers can easily pass in their own name if they fork the repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
