### PR TITLE
fix: Switch to USER_SRP_AUTH auth flow type

### DIFF
--- a/static-website/src/config.js
+++ b/static-website/src/config.js
@@ -9,5 +9,4 @@ export const SAR_API_ENDPOINT = '${SAR_BACKEND_ENDPOINT}';
 export const COGNITO_USER_POOL_DATA = {
   userPoolId: '${USER_POOL_ID}',
   userPoolWebClientId: '${USER_POOL_WEB_CLIENT_ID}',
-  authenticationFlowType: 'USER_PASSWORD_AUTH',
 };


### PR DESCRIPTION
*Issue #, if available:* #50 

*Testing*
Ran website with new config locally. AuthN works fine. Inspected the requests and verified that the default USER_SRP_AUTH is now being used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
