### PR TITLE
Await Firehose resource creation until FirehoseToS3Policy is attached…

### DIFF
--- a/analytics/sam/app/template.yaml
+++ b/analytics/sam/app/template.yaml
@@ -182,6 +182,7 @@ Resources:
 
   Firehose:
     Type: AWS::KinesisFirehose::DeliveryStream
+    DependsOn: FirehoseToS3Policy
     Properties:
       DeliveryStreamType: DirectPut
       ExtendedS3DestinationConfiguration:


### PR DESCRIPTION
When following the guide on [aws blogs](https://aws.amazon.com/blogs/opensource/real-world-serverless-application/) one might not be able to deploy the application.

The `FirehoseS3Role` does not have the right permissions when it tries to deploy the `Firehose`. To be sure the permission are correct we  have to wait with deploying the `Firehose` resource until the correct policy is created and attached.