### PR TITLE
fix: Add update sqs permissions for analytics cicd role

### DIFF
--- a/analytics/sam/cicd/template.yaml
+++ b/analytics/sam/cicd/template.yaml
@@ -147,6 +147,7 @@ Resources:
               - sqs:DeleteQueue
               - sqs:TagQueue
               - sqs:GetQueueAttributes
+              - sqs:SetQueueAttributes
             Resource:
               - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow


### PR DESCRIPTION
This is to fix a stack update [failure](https://console.aws.amazon.com/codesuite/codepipeline/pipelines/realworld-serverless-application-analytics-cd-CD-130D8OI77SOXL-Pipeline-1GH4ZF3ZOVPWE/view?region=us-east-1) in the analytics CodePipeline

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
