### PR TITLE
fix: Add missing GetFunctions permissions to cicd templates

### DIFF
--- a/analytics/sam/cicd/template.yaml
+++ b/analytics/sam/cicd/template.yaml
@@ -265,6 +265,7 @@ Resources:
             Action:
               - lambda:CreateFunction
               - lambda:GetFunctionConfiguration
+              - lambda:GetFunction
               - lambda:DeleteFunction
               - lambda:CreateAlias
               - lambda:GetAlias

--- a/backend/sam/cicd/template.yaml
+++ b/backend/sam/cicd/template.yaml
@@ -140,6 +140,7 @@ Resources:
             Action:
               - lambda:CreateFunction
               - lambda:GetFunctionConfiguration
+              - lambda:GetFunction
               - lambda:DeleteFunction
               - lambda:CreateAlias
               - lambda:GetAlias

--- a/static-website/sam/cicd/template.yaml
+++ b/static-website/sam/cicd/template.yaml
@@ -218,6 +218,7 @@ Resources:
             Action:
               - lambda:CreateFunction
               - lambda:GetFunctionConfiguration
+              - lambda:GetFunction
               - lambda:DeleteFunction
               - lambda:CreateAlias
               - lambda:GetAlias


### PR DESCRIPTION
Three pipelines started failing tests after the previous permissions
fix.  Presumably a change was previously made that wasn't added to code
and so was overwritten.

This fix passes in the analytics and backend pipelines.  The
static-website pipeline is still failing but for an unrelated issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
